### PR TITLE
docs: add Oracle ADF quirks and debugging guides

### DIFF
--- a/docs/DEBUGGING.md
+++ b/docs/DEBUGGING.md
@@ -1,0 +1,135 @@
+# Debugging Guide
+
+This guide explains how to debug common runtime issues when scraping SIA.
+
+## Enable debug logging
+
+Set `SIA_DEBUG=1` before running your script:
+
+```bash
+export SIA_DEBUG=1
+python your_script.py
+```
+
+When enabled, the scraper logs Oracle ADF state transitions and selected request
+metadata through the project logger.
+
+## Recommended logger setup
+
+```python
+import logging
+
+logging.basicConfig(level=logging.DEBUG)
+```
+
+If logging is not configured, debug messages may not be visible even with
+`SIA_DEBUG=1`.
+
+## What to inspect first
+
+1. Session status transitions
+2. ViewState evolution across POST requests
+3. Dropdown action order for career selection
+4. Course list size before row selection
+5. DELTAS payload for selected row
+
+## Common issues and checks
+
+## 1) `InvalidStatus` exceptions
+
+Cause: calling an action from the wrong state.
+
+Checks:
+
+- Confirm current status before operation.
+- Ensure workflow order is respected: create session -> set career -> get course info.
+
+Example:
+
+```python
+from sia_scraper import SiaScraper
+
+scraper = SiaScraper(init_session=False)
+scraper.create_session()
+print(scraper.sia_session.STATUS)
+scraper.set_career("0-2-8-3")
+print(scraper.sia_session.STATUS)
+```
+
+## 2) Wrong course details for a selected index
+
+Cause: stale ADF state (usually ViewState drift).
+
+Checks:
+
+- Verify each course-related POST is going through `post_request()`.
+- Confirm no custom code bypasses session methods and sends raw POSTs.
+
+Example anti-pattern:
+
+```python
+# Bad: bypasses state sync logic
+session._SiaSession__session.post(session_url, data=payload)
+```
+
+Preferred pattern:
+
+```python
+# Good: keeps ViewState synchronized
+session.post_request(payload)
+```
+
+## 3) `ValueError` in course parsing
+
+Cause: live SIA payload differences for a specific row.
+
+Checks:
+
+- Retry another nearby course index.
+- Validate page content contains expected `detass-creditos` and course title elements.
+
+Example fallback pattern:
+
+```python
+course_info = None
+for idx in range(min(5, len(scraper.course_list))):
+    try:
+        course_info = scraper.get_course_info(course_index=idx)
+        break
+    except ValueError:
+        continue
+```
+
+## 4) Career loads but course list is empty
+
+Cause: incomplete ADF action chain or changed component behavior.
+
+Checks:
+
+- Verify action sequence in `set_career()` completes.
+- Confirm `search_code` format is `level-campus-faculty-career`.
+- Test another known career code.
+
+## Debug command checklist
+
+Run these checks locally after changes:
+
+```bash
+pytest
+ruff check --fix . && ruff format . && ruff check .
+pyright
+```
+
+Run only integration tests:
+
+```bash
+pytest tests/test_integration.py -v
+```
+
+## Useful files for troubleshooting
+
+- `src/sia_scraper/session.py`
+- `src/sia_scraper/oracle_adf_request.py`
+- `src/sia_scraper/adf_state.py`
+- `src/sia_scraper/parsers/course_parser.py`
+- `tests/test_integration.py`

--- a/docs/QUIRKS.md
+++ b/docs/QUIRKS.md
@@ -1,0 +1,126 @@
+# Oracle ADF Quirks
+
+This document captures Oracle ADF behavior we have observed while scraping SIA,
+plus how the library currently handles each case.
+
+## 1) ViewState changes after POST (critical)
+
+Oracle ADF rotates `javax.faces.ViewState` after state-changing requests. Reusing
+an older token can make the server apply actions against stale component state.
+
+### Symptom
+
+- wrong course detail payload for a selected row
+- inconsistent table behavior after multiple POST calls
+
+### How we manage it
+
+- ViewState is extracted from every POST response and immediately stored.
+- Request body generation happens per-step so each POST uses the latest ViewState.
+
+### Example
+
+```python
+def post_request(self, data: dict[str, str]) -> Any:
+    response = self.__session.post(
+        self.__url,
+        params=self.__params,
+        headers=http.SIA_HEADERS,
+        data=data,
+    )
+    self.sync_view_state_from_response(response)
+    return response
+```
+
+## 2) Strict action order in dependent dropdowns
+
+SIA's Oracle ADF flow requires selecting filters in sequence. Sending only the
+final target value (career or typology) is not enough.
+
+### Required sequence
+
+`STUDY_LEVEL_DD -> CAMPUS_DD -> FACULTY_DD -> CAREER_DD -> TIPOLOGY_DD -> SHOW_COURSES_BTTN`
+
+Electives include additional steps before show.
+
+### How we manage it
+
+- We execute a full action sequence in `set_career()`.
+- Each step sends its own event payload and receives fresh state.
+
+### Example
+
+```python
+for action in action_sequence:
+    self.__init_request_dict()
+    self.request_dict[adf_ids.STUDY_LEVEL_DD_ID] = self.career_indices[0]
+    self.request_dict[adf_ids.CAMPUS_DD_ID] = self.career_indices[1]
+    self.request_dict[adf_ids.FACULTY_DD_ID] = self.career_indices[2]
+    self.request_dict[adf_ids.CAREER_DD_ID] = self.career_indices[3]
+    data = self._generate_request_body(action)
+    self.post_request(data=data)
+```
+
+## 3) Token trio required in every POST
+
+Most ADF interactions require:
+
+- `Adf-Window-Id`
+- `Adf-Page-Id`
+- `javax.faces.ViewState`
+
+### How we manage it
+
+- Tokens are captured on session initialization.
+- The request builder injects them into each request body.
+
+### Example
+
+```python
+self.request_dict = {
+    "Adf-Window-Id": self.session._window_id or "",
+    "Adf-Page-Id": self.session._page_id or "",
+    "javax.faces.ViewState": self.session._view_state or "",
+}
+```
+
+## 4) Table row selection needs DELTAS metadata
+
+Selecting a course row is not only about event name; ADF expects a matching
+`oracle.adf.view.rich.DELTAS` payload describing table viewport and row state.
+
+### How we manage it
+
+- DELTAS is built dynamically from current course list size.
+- `selectedRowKeys` is set to the requested course index.
+
+### Example
+
+```python
+specific_request_dict["oracle.adf.view.rich.DELTAS"] = (
+    f"{{pt1:r1:0:t4={{viewportSize={len(course_list) + 1},"
+    f"rows={len(course_list)},selectedRowKeys={idx}}}}}"
+)
+```
+
+## 5) Component IDs are brittle
+
+ADF IDs are tied to rendered component structure (for example `pt1:r1:0:soc2`).
+Changes in SIA frontend structure can break scraping flows.
+
+### How we manage it
+
+- IDs are centralized in constants modules.
+- Integration tests exercise real requests against SIA.
+
+## Historical note: index 0/1 swap observation
+
+We previously documented apparent index `0/1` swapping during course detail
+navigation. After implementing ViewState auto-sync, that behavior stopped
+reproducing consistently and is currently treated as state-drift related.
+
+## Operational guidance
+
+- Keep `post_request()` as the only place where ViewState sync is guaranteed.
+- Avoid precomputing long request chains with a single stale request dictionary.
+- If scraping starts returning mismatched rows, verify ViewState and DELTAS first.


### PR DESCRIPTION
## Summary
- add `docs/QUIRKS.md` documenting Oracle ADF quirks we have encountered and how the scraper mitigates them
- add `docs/DEBUGGING.md` with practical troubleshooting steps, logging setup, and code-level debugging patterns
- include concrete code examples for ViewState sync, strict action ordering, and parser fallback strategies

## Why
SIA is backed by Oracle ADF and behaves like a stateful JSF app, so scraper failures are often state-related instead of obvious request errors. Centralizing the known quirks and debugging workflow reduces maintenance cost and speeds up issue triage.

## Notes
- docs-only change
- no runtime code modified