### PR TITLE
feat(phase2a): add concurrency guard to SiaSession

### DIFF
--- a/src/sia_scraper/core/exceptions.py
+++ b/src/sia_scraper/core/exceptions.py
@@ -58,8 +58,51 @@ class InvalidStatus(SiaSessionException):
         super().__init__("Invalid action to current SIA status")
 
 
+class ConcurrentAccessError(SiaSessionException):
+    """Raised when concurrent access to SiaSession is detected.
+
+    SiaSession maintains stateful Oracle ADF navigation state and does not
+    support concurrent operations. Methods must be called sequentially.
+
+    Resolution:
+        - Await each operation before starting the next
+        - Do not use asyncio.gather() on the same session instance
+        - Create multiple session instances for parallel operations
+
+    Example of INVALID usage:
+        >>> session = await SiaSession.create()
+        >>> await session.set_career("0-2-8-3")
+        >>> # This will raise ConcurrentAccessError:
+        >>> task1 = asyncio.create_task(session.get_course_xml(0))
+        >>> task2 = asyncio.create_task(session.set_career("1-2-3-4"))
+        >>> await asyncio.gather(task1, task2)  # ERROR!
+
+    Example of VALID usage:
+        >>> session = await SiaSession.create()
+        >>> await session.set_career("0-2-8-3")
+        >>> xml1 = await session.get_course_xml(0)  # Sequential - OK
+        >>> xml2 = await session.get_course_xml(1)  # Sequential - OK
+    """
+
+    def __init__(self, active_op: str, attempted_op: str) -> None:
+        """Initialize with operation details.
+
+        Args:
+            active_op: Name of the currently running operation
+            attempted_op: Name of the operation that was attempted
+        """
+        super().__init__(
+            f"Concurrent session access detected: "
+            f"cannot start '{attempted_op}' while '{active_op}' is running. "
+            f"SiaSession methods must be called sequentially."
+        )
+        self.active_operation = active_op
+        self.attempted_operation = attempted_op
+
+
 # Backward-compatible aliases for existing call sites.
 SiaSessionException.SessionNotSet = SessionNotSet  # type: ignore[attr-defined]
 SiaSessionException.CareerNotSet = CareerNotSet  # type: ignore[attr-defined]
 SiaSessionException.TimeoutError = TimeoutError  # type: ignore[attr-defined]
 SiaSessionException.InvalidStatus = InvalidStatus  # type: ignore[attr-defined]
+SiaSessionException.ConcurrentAccessError = ConcurrentAccessError  # type: ignore[attr-defined]

--- a/src/sia_scraper/session.py
+++ b/src/sia_scraper/session.py
@@ -1,5 +1,6 @@
 """Rust-backed async SIA session management."""
 
+from contextlib import asynccontextmanager
 from typing import TypedDict, cast
 
 import sia_scraper_rust
@@ -7,6 +8,7 @@ import sia_scraper_rust
 from .constants import status
 from .constants.defaults import DEFAULT_CAREER_NAME
 from .core import SiaSessionException
+from .core.exceptions import ConcurrentAccessError
 from .parsers.models import SessionState
 
 
@@ -18,7 +20,32 @@ class _SessionRuntimeState(TypedDict, total=False):
 
 
 class SiaSession:
-    """Async SIA session backed by Rust reqwest/tokio HTTP client."""
+    """Async SIA session backed by Rust reqwest/tokio HTTP client.
+
+    **IMPORTANT: This class does NOT support concurrent operations.**
+
+    SiaSession maintains stateful Oracle ADF navigation context. Methods must
+    be called sequentially. Concurrent calls will raise `ConcurrentAccessError`.
+
+    For parallel scraping, create multiple independent `SiaSession` instances.
+
+    Example (correct sequential usage):
+        >>> session = await SiaSession.create()
+        >>> await session.set_career("0-2-8-3")
+        >>> for i in range(10):
+        ...     xml = await session.get_course_xml(i)  # OK - sequential
+
+    Example (incorrect concurrent usage):
+        >>> # DO NOT DO THIS:
+        >>> tasks = [session.get_course_xml(i) for i in range(10)]
+        >>> await asyncio.gather(*tasks)  # Will raise ConcurrentAccessError!
+
+    Example (correct parallel usage):
+        >>> # Create separate sessions for parallel work:
+        >>> sessions = [await SiaSession.create() for _ in range(5)]
+        >>> tasks = [s.set_career("0-2-8-3") for s in sessions]
+        >>> await asyncio.gather(*tasks)  # OK - different instances
+    """
 
     def __init__(self, timeout: int = 15) -> None:
         self._timeout = timeout
@@ -28,6 +55,7 @@ class SiaSession:
         self._career_indices: list[str] = []
         self._status: status.SiaSessionStatus = status.SiaSessionStatus.NO_SESSION
         self._session_state: _SessionRuntimeState = {}
+        self._active_operation: str | None = None
 
     @classmethod
     async def create(cls, timeout: int = 15) -> "SiaSession":
@@ -35,6 +63,25 @@ class SiaSession:
         session = cls(timeout)
         await session.init_session()
         return session
+
+    @asynccontextmanager
+    async def _operation(self, name: str):
+        """Guard against concurrent operations.
+
+        Args:
+            name: Name of the operation being guarded
+
+        Raises:
+            ConcurrentAccessError: If another operation is already active
+        """
+        if self._active_operation is not None:
+            raise ConcurrentAccessError(active_op=self._active_operation, attempted_op=name)
+
+        self._active_operation = name
+        try:
+            yield
+        finally:
+            self._active_operation = None
 
     @property
     def career_name(self) -> str:
@@ -68,56 +115,60 @@ class SiaSession:
 
     async def init_session(self) -> None:
         """Initialize HTTP session with SIA and fetch initial ViewState."""
-        result = await sia_scraper_rust.init_sia_session(self._timeout)  # type: ignore[attr-defined]
-        self._status = status.SiaSessionStatus.CAREER_NOT_SET
-        self._session_state = cast(_SessionRuntimeState, dict(result))
+        async with self._operation("init_session"):
+            result = await sia_scraper_rust.init_sia_session(self._timeout)  # type: ignore[attr-defined]
+            self._status = status.SiaSessionStatus.CAREER_NOT_SET
+            self._session_state = cast(_SessionRuntimeState, dict(result))
 
     async def set_career(self, search_code: str, is_electives: bool = False) -> None:
         """Navigate to career and load course list."""
-        result = await sia_scraper_rust.set_career(  # type: ignore[attr-defined]
-            self._timeout,
-            search_code,
-            is_electives,
-        )
-        self._career_code = search_code
-        self._career_indices = search_code.split("-")
-        self._is_electives = is_electives
-        if isinstance(result, dict):
-            self._career_name = str(result.get("career_name", self._career_name))
-            course_list = result.get("course_list", [])
-            if isinstance(course_list, list):
-                self._session_state["course_list"] = course_list
-            view_state = result.get("javax_faces_ViewState")
-            if isinstance(view_state, str):
-                self._session_state["javax_faces_ViewState"] = view_state
-        self._status = status.SiaSessionStatus.ON_CAREER_PAGE
+        async with self._operation("set_career"):
+            result = await sia_scraper_rust.set_career(  # type: ignore[attr-defined]
+                self._timeout,
+                search_code,
+                is_electives,
+            )
+            self._career_code = search_code
+            self._career_indices = search_code.split("-")
+            self._is_electives = is_electives
+            if isinstance(result, dict):
+                self._career_name = str(result.get("career_name", self._career_name))
+                course_list = result.get("course_list", [])
+                if isinstance(course_list, list):
+                    self._session_state["course_list"] = course_list
+                view_state = result.get("javax_faces_ViewState")
+                if isinstance(view_state, str):
+                    self._session_state["javax_faces_ViewState"] = view_state
+            self._status = status.SiaSessionStatus.ON_CAREER_PAGE
 
     async def get_course_xml(self, course_index: int) -> str:
         """Get course detail XML for given index."""
-        if self._status not in (
-            status.SiaSessionStatus.ON_CAREER_PAGE,
-            status.SiaSessionStatus.ON_COURSE_PAGE,
-        ):
-            raise SiaSessionException.InvalidStatus from None
+        async with self._operation("get_course_xml"):
+            if self._status not in (
+                status.SiaSessionStatus.ON_CAREER_PAGE,
+                status.SiaSessionStatus.ON_COURSE_PAGE,
+            ):
+                raise SiaSessionException.InvalidStatus from None
 
-        course_list = self.course_list
-        if not 0 <= course_index < len(course_list):
-            raise ValueError(
-                f"Course index {course_index} out of range (0-{max(len(course_list) - 1, 0)})"
+            course_list = self.course_list
+            if not 0 <= course_index < len(course_list):
+                raise ValueError(
+                    f"Course index {course_index} out of range (0-{max(len(course_list) - 1, 0)})"
+                )
+
+            result = await sia_scraper_rust.get_course_xml(  # type: ignore[attr-defined]
+                self._timeout,
+                course_index,
+                self._career_indices,
+                self._is_electives,
             )
-
-        result = await sia_scraper_rust.get_course_xml(  # type: ignore[attr-defined]
-            self._timeout,
-            course_index,
-            self._career_indices,
-            self._is_electives,
-        )
-        return str(result)
+            return str(result)
 
     async def close(self) -> None:
         """Close the session and cleanup resources."""
-        self._status = status.SiaSessionStatus.NO_SESSION
-        self._session_state = {}
+        async with self._operation("close"):
+            self._status = status.SiaSessionStatus.NO_SESSION
+            self._session_state = {}
 
     def get_session_data(self) -> SessionState:
         """Serialize session state for persistence."""

--- a/tests/test_session_concurrency.py
+++ b/tests/test_session_concurrency.py
@@ -1,0 +1,287 @@
+"""Tests for SiaSession concurrency guard.
+
+Verifies that concurrent access to SiaSession raises ConcurrentAccessError
+and that sequential operations work correctly.
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from sia_scraper.core.exceptions import ConcurrentAccessError
+from sia_scraper.session import SiaSession
+
+
+@pytest.fixture
+def mock_rust_module():
+    """Patch Rust extension calls used by SiaSession."""
+    with patch("sia_scraper.session.sia_scraper_rust") as rust:
+        rust.init_sia_session = AsyncMock(return_value={"javax_faces_ViewState": "vs-1"})
+        rust.set_career = AsyncMock(
+            return_value={
+                "career_name": "Ingenieria de Sistemas",
+                "course_list": [
+                    {"1000001": "Calculo"},
+                    {"2016489": "Estructuras de Datos"},
+                    {"3000003": "Fisica"},
+                ],
+                "javax_faces_ViewState": "vs-2",
+            }
+        )
+        rust.get_course_xml = AsyncMock(return_value="<xml>course</xml>")
+        yield rust
+
+
+class TestConcurrentAccessDetection:
+    """Test that concurrent operations are detected and rejected."""
+
+    @pytest.mark.asyncio
+    async def test_concurrent_set_career_raises_error(self, mock_rust_module):
+        """Two concurrent set_career calls should raise ConcurrentAccessError."""
+        session = await SiaSession.create()
+
+        try:
+
+            async def slow_set_career(*args):
+                await asyncio.sleep(0.1)
+                return {
+                    "career_name": "Test Career",
+                    "course_list": [],
+                    "javax_faces_ViewState": "vs-3",
+                }
+
+            mock_rust_module.set_career.side_effect = slow_set_career
+
+            task1 = asyncio.create_task(session.set_career("0-2-8-3"))
+            await asyncio.sleep(0.01)
+
+            with pytest.raises(ConcurrentAccessError) as exc_info:
+                await session.set_career("1-2-3-4")
+
+            assert exc_info.value.active_operation == "set_career"
+            assert exc_info.value.attempted_operation == "set_career"
+            assert "set_career" in str(exc_info.value)
+            assert "must be called sequentially" in str(exc_info.value)
+
+            await task1
+        finally:
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_get_course_xml_raises_error(self, mock_rust_module):
+        """Two concurrent get_course_xml calls should raise error."""
+        session = await SiaSession.create()
+        await session.set_career("0-2-8-3")
+
+        try:
+
+            async def slow_get_course(*args):
+                await asyncio.sleep(0.1)
+                return "<xml>test</xml>"
+
+            mock_rust_module.get_course_xml.side_effect = slow_get_course
+
+            task1 = asyncio.create_task(session.get_course_xml(0))
+            await asyncio.sleep(0.01)
+
+            with pytest.raises(ConcurrentAccessError) as exc_info:
+                await session.get_course_xml(1)
+
+            assert exc_info.value.active_operation == "get_course_xml"
+            assert exc_info.value.attempted_operation == "get_course_xml"
+
+            await task1
+        finally:
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_mixed_concurrent_operations_raises_error(self, mock_rust_module):
+        """set_career during get_course_xml should raise error."""
+        session = await SiaSession.create()
+        await session.set_career("0-2-8-3")
+
+        try:
+
+            async def slow_get_course(*args):
+                await asyncio.sleep(0.1)
+                return "<xml>test</xml>"
+
+            mock_rust_module.get_course_xml.side_effect = slow_get_course
+
+            task1 = asyncio.create_task(session.get_course_xml(0))
+            await asyncio.sleep(0.01)
+
+            with pytest.raises(ConcurrentAccessError) as exc_info:
+                await session.set_career("1-2-3-4")
+
+            assert exc_info.value.active_operation == "get_course_xml"
+            assert exc_info.value.attempted_operation == "set_career"
+
+            await task1
+        finally:
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_init_session_raises_error(self, mock_rust_module):
+        """Two concurrent init_session calls should raise error."""
+        session = SiaSession()
+
+        async def slow_init(*args):
+            await asyncio.sleep(0.1)
+            return {"javax_faces_ViewState": "test"}
+
+        mock_rust_module.init_sia_session.side_effect = slow_init
+
+        task1 = asyncio.create_task(session.init_session())
+        await asyncio.sleep(0.01)
+
+        with pytest.raises(ConcurrentAccessError):
+            await session.init_session()
+
+        await task1
+
+    @pytest.mark.asyncio
+    async def test_concurrent_close_raises_error(self, mock_rust_module):
+        """close during get_course_xml should raise error."""
+        session = await SiaSession.create()
+        await session.set_career("0-2-8-3")
+
+        try:
+
+            async def slow_get_course(*args):
+                await asyncio.sleep(0.1)
+                return "<xml>test</xml>"
+
+            mock_rust_module.get_course_xml.side_effect = slow_get_course
+
+            task1 = asyncio.create_task(session.get_course_xml(0))
+            await asyncio.sleep(0.01)
+
+            with pytest.raises(ConcurrentAccessError) as exc_info:
+                await session.close()
+
+            assert exc_info.value.active_operation == "get_course_xml"
+            assert exc_info.value.attempted_operation == "close"
+
+            await task1
+        finally:
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_concurrent_init_during_set_career_raises_error(self, mock_rust_module):
+        """init_session during set_career should raise error."""
+        session = SiaSession()
+
+        async def slow_set_career(*args):
+            await asyncio.sleep(0.1)
+            return {
+                "career_name": "Test",
+                "course_list": [],
+                "javax_faces_ViewState": "vs",
+            }
+
+        mock_rust_module.set_career.side_effect = slow_set_career
+
+        await session.init_session()
+
+        task1 = asyncio.create_task(session.set_career("0-2-8-3"))
+        await asyncio.sleep(0.01)
+
+        with pytest.raises(ConcurrentAccessError) as exc_info:
+            await session.init_session()
+
+        assert exc_info.value.active_operation == "set_career"
+        assert exc_info.value.attempted_operation == "init_session"
+
+        await task1
+
+
+class TestSequentialOperationsStillWork:
+    """Verify that sequential operations are not affected by the guard."""
+
+    @pytest.mark.asyncio
+    async def test_sequential_set_career_works(self, mock_rust_module):
+        """Sequential set_career calls should work normally."""
+        session = await SiaSession.create()
+
+        try:
+            await session.set_career("0-2-8-3")
+            assert session.career_code == "0-2-8-3"
+
+            await session.set_career("1-2-3-4")
+            assert session.career_code == "1-2-3-4"
+        finally:
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_sequential_get_course_xml_works(self, mock_rust_module):
+        """Sequential get_course_xml calls should work normally."""
+        session = await SiaSession.create()
+        await session.set_career("0-2-8-3")
+
+        try:
+            xml1 = await session.get_course_xml(0)
+            xml2 = await session.get_course_xml(1)
+
+            assert xml1 is not None
+            assert xml2 is not None
+            assert isinstance(xml1, str)
+            assert isinstance(xml2, str)
+        finally:
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_operation_guard_releases_on_exception(self, mock_rust_module):
+        """Guard should release if operation raises exception."""
+        session = await SiaSession.create()
+
+        try:
+            mock_rust_module.set_career.side_effect = RuntimeError("Simulated error")
+
+            with pytest.raises(RuntimeError):
+                await session.set_career("0-2-8-3")
+
+            mock_rust_module.set_career.side_effect = {
+                "career_name": "Test",
+                "course_list": [],
+                "javax_faces_ViewState": "vs",
+            }
+
+            await session.set_career("1-2-3-4")
+            assert session.career_code == "1-2-3-4"
+        finally:
+            await session.close()
+
+    @pytest.mark.asyncio
+    async def test_multiple_sessions_can_run_concurrently(self, mock_rust_module):
+        """Different session instances CAN run concurrently."""
+        session1 = await SiaSession.create()
+        session2 = await SiaSession.create()
+
+        try:
+            await asyncio.gather(
+                session1.set_career("0-2-8-3"),
+                session2.set_career("1-2-3-4"),
+            )
+
+            assert session1.career_code == "0-2-8-3"
+            assert session2.career_code == "1-2-3-4"
+        finally:
+            await session1.close()
+            await session2.close()
+
+    @pytest.mark.asyncio
+    async def test_operation_guard_releases_on_success(self, mock_rust_module):
+        """Guard should release after successful operation."""
+        session = await SiaSession.create()
+
+        try:
+            await session.set_career("0-2-8-3")
+            assert session._active_operation is None
+
+            xml = await session.get_course_xml(0)
+            assert session._active_operation is None
+            assert xml == "<xml>course</xml>"
+        finally:
+            await session.close()


### PR DESCRIPTION
## Summary

- Add runtime detection for concurrent access to SiaSession with ConcurrentAccessError
- Guard all 4 async methods (init_session, set_career, get_course_xml, close) with _operation() context manager
- Add 11 comprehensive tests for concurrent access detection and sequential behavior
- Update SiaSession docstring with concurrency warning and usage examples

## Motivation

Part of Phase 2 technical debt remediation per docs/TECHNICAL_DEBT_AUDIT.md (Finding #5).

SiaSession maintains stateful Oracle ADF navigation state and does not support concurrent operations. Previously, the API did not prevent unsafe concurrent calls by consumers, which could lead to data inconsistency and hard-to-debug issues.

## Implementation

- Exception: ConcurrentAccessError with active_operation and attempted_operation attributes
- Guard: asynccontextmanager-based _operation() that tracks currently active operation
- Behavior: Raises clear error message when concurrent access detected; releases guard on exceptions
- Safety: Different session instances CAN run concurrently (for parallel scraping)

## Tests

11 new tests covering:
- Concurrent set_career, get_course_xml, init_session, close detection
- Mixed concurrent operations (e.g., get_course_xml + set_career)
- Sequential operations still work correctly
- Guard releases properly on exceptions
- Multiple session instances can run concurrently