### PR TITLE
fix: remove eval from check scripts (PR #1)

### DIFF
--- a/scripts/check-python.sh
+++ b/scripts/check-python.sh
@@ -19,11 +19,10 @@ total=0
 
 run_check() {
     local name="$1"; shift
-    local cmd="$*"
     local output
     ((total++))
     echo -e "${RESET}━━━ $name ━━━"
-    if output=$(eval "$cmd" 2>&1); then
+    if output=$("$@" 2>&1); then
         echo -e "${GREEN}✓ $name passed${RESET}"
     else
         echo -e "${RED}✗ $name failed${RESET}"

--- a/scripts/check-rust.sh
+++ b/scripts/check-rust.sh
@@ -19,11 +19,10 @@ total=0
 
 run_check() {
     local name="$1"; shift
-    local cmd="$*"
     local output
     ((total++))
     echo -e "${RESET}━━━ $name ━━━"
-    if output=$(eval "$cmd" 2>&1); then
+    if output=$("$@" 2>&1); then
         echo -e "${GREEN}✓ $name passed${RESET}"
     else
         echo -e "${RED}✗ $name failed${RESET}"


### PR DESCRIPTION
## Summary

Remove `eval` from shell scripts for safer command execution.

### Changes

- **scripts/check-python.sh**: Changed `eval "$cmd"` to `"$@"` in `run_check()` function
- **scripts/check-rust.sh**: Changed `eval "$cmd"` to `"$@"` in `run_check()` function

### Why

`eval` introduces security risks and makes debugging harder. With the refactor:
- Commands are now passed as separate arguments to `run_check()`
- Direct execution via `"$@"` avoids string injection issues
- Maintains the same functionality

### Verification

- `./scripts/check-python.sh` ✅ passes
- `./scripts/check-rust.sh` ✅ passes

## Related

- CodeRabbit finding: "Consider avoiding eval for safer command execution"