### PR TITLE
fix(test.yml): clean stale wheels before build (PR #6)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,7 @@ jobs:
       - name: Build wheel and install
         run: |
           pip install maturin
+          rm -f target/wheels/sia_scraper-*.whl
           maturin build --release --interpreter python${{ matrix.python-version }}
           pip install target/wheels/sia_scraper-*.whl
 


### PR DESCRIPTION
## Summary

Clean stale wheel files before building to prevent installation conflicts.

### Changes

- **.github/workflows/test.yml**: Added `rm -f target/wheels/sia_scraper-*.whl` before `maturin build`

### Why

If previous builds left wheels in target/wheels/, the glob `sia_scraper-*.whl` could match multiple files, causing pip to install an older or unintended version. This ensures only the newly built wheel is installed.

## Related

- CodeRabbit finding: "Glob pattern may match multiple wheels if artifacts aren't cleaned"