### PR TITLE
fix: use TypeError for type validation errors (PR #9, #10)

### DIFF
--- a/src/sia_scraper/scraper.py
+++ b/src/sia_scraper/scraper.py
@@ -322,10 +322,7 @@ class SiaScraper:
         elif isinstance(error_mode, str):
             mode = error_mode.lower()
         else:
-            raise ValueError(
-                f"Invalid error_mode: {error_mode!r}. Must be an ErrorMode or one of: "
-                f"{', '.join(sorted({'abort', 'skip', 'retry'}))}"
-            )
+            raise TypeError(f"error_mode must be ErrorMode or str, got {type(error_mode).__name__}")
         valid_modes = {"abort", "skip", "retry"}
         if mode not in valid_modes:
             raise ValueError(

--- a/src/sia_scraper/session.py
+++ b/src/sia_scraper/session.py
@@ -124,7 +124,7 @@ class SiaSession:
         """Validate course list format (defense-in-depth)."""
         for i, course in enumerate(self._course_list):
             if not isinstance(course, dict):
-                raise ValueError(
+                raise TypeError(
                     f"Invalid course list format at index {i}: {type(course).__name__}. "
                     "Expected dict with 'code' and 'name' string keys."
                 )
@@ -136,7 +136,7 @@ class SiaSession:
             code_val = course["code"]
             name_val = course["name"]
             if not isinstance(code_val, str) or not isinstance(name_val, str):
-                raise ValueError(
+                raise TypeError(
                     f"Invalid course list format at index {i}: code={code_val!r}, name={name_val!r}. "
                     "Expected 'code' and 'name' values to be strings."
                 )


### PR DESCRIPTION
## Summary

Per Ruff TRY004, use TypeError for isinstance() failures instead of ValueError.

### Changes

1. **src/sia_scraper/session.py** (`_validate_course_list`):
   - `not isinstance(course, dict)` → raises TypeError
   - `not isinstance(code_val, str) or not isinstance(name_val, str)` → raises TypeError
   - Kept ValueError for missing keys (semantic error, not type error)

2. **src/sia_scraper/scraper.py** (`_resolve_error_mode`):
   - Invalid type (not ErrorMode or str) → raises TypeError
   - Kept ValueError for invalid mode string value

### Verification

- `ruff check` ✅ passes
- `pyright` ✅ 0 errors
- `pytest tests/test_scraper.py -k test_scrape_courses` ✅ 4 passed

## Related

- CodeRabbit findings: "Consider using TypeError for type validation failures"