### PR TITLE
test: remove redundant scope='function' from fixture

### DIFF
--- a/tests/rust/test_batch_scraping.py
+++ b/tests/rust/test_batch_scraping.py
@@ -13,7 +13,7 @@ import pytest
 sia_scraper_rust = pytest.importorskip("sia_scraper_rust")
 
 
-@pytest.fixture(scope="function")
+@pytest.fixture
 async def initialized_session():
     """Provide an initialized PySiaSession with cleanup.
 


### PR DESCRIPTION
## Summary

- Remove redundant `scope="function"` from `@pytest.fixture` in `tests/rust/test_batch_scraping.py`
- Pytest fixtures default to function scope, making explicit declaration unnecessary

CodeRabbit finding from PR #104.