### PR TITLE
stub: use Literal type for ErrorModeStr

### DIFF
--- a/stubs/sia_scraper_rust.pyi
+++ b/stubs/sia_scraper_rust.pyi
@@ -16,9 +16,9 @@ Example:
 """
 
 from collections.abc import Awaitable
-from typing import Any, TypedDict
+from typing import Any, Literal, TypedDict
 
-ErrorModeStr = str
+ErrorModeStr = Literal["abort", "skip", "retry"]
 
 class SiaScraperException(Exception):
     """Custom exception raised by sia_scraper_rust for parsing and validation errors.


### PR DESCRIPTION
## Summary

- Change `ErrorModeStr = str` to `ErrorModeStr = Literal["abort", "skip", "retry"]` in stubs
- Add `Literal` import to typing imports

CodeRabbit finding from PR #104.